### PR TITLE
Can't parse result with analysis-core version greater than 1.62

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>analysis-core</artifactId>
-      <version>1.58</version>
+      <version>1.64</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>


### PR DESCRIPTION
tasks-4.43 has been compiled with the old version of analysis-core
addAnnotation method returns void before and now an int.

fixed JENKINS-25407
