### PR TITLE
[JENKINS-29704] Workflow compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>1.59</version>
+    <version>1.63</version>
   </parent>
 
   <artifactId>tasks</artifactId>
@@ -15,6 +15,10 @@
   <description>This plug-in scans the workspace files for open tasks
     and generates a trend report.
   </description>
+
+  <properties>
+    <workflow.version>1.4</workflow.version>
+  </properties>
 
   <licenses>
     <license>
@@ -37,12 +41,30 @@
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>analysis-core</artifactId>
-      <version>1.73-SNAPSHOT</version>
+      <version>1.73-beta-SNAPSHOT</version><!-- TODO: change to 1.73 before release -->
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>analysis-test</artifactId>
       <version>1.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>${workflow.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>${workflow.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/hudson/plugins/tasks/FixedTasksDetail.java
+++ b/src/main/java/hudson/plugins/tasks/FixedTasksDetail.java
@@ -1,6 +1,8 @@
 package hudson.plugins.tasks;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+
 import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.views.DetailFactory;
 import hudson.plugins.analysis.views.FixedWarningsDetail;
@@ -28,13 +30,31 @@ public class FixedTasksDetail extends FixedWarningsDetail {
      * @param header
      *            header to be shown on detail page
      */
-    public FixedTasksDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> fixedTasks, final String defaultEncoding, final String header) {
+    public FixedTasksDetail(final Run<?, ?> owner, final Collection<FileAnnotation> fixedTasks, final String defaultEncoding, final String header) {
         super(owner, new DetailFactory(), fixedTasks, defaultEncoding, header);
     }
 
     @Override
     public String getDisplayName() {
         return Messages.FixedTasksDetail_Name();
+    }
+
+    /**
+     * Creates a new instance of {@link FixedTasksDetail}.
+     *
+     * @param owner
+     *            the current results object as owner of this action
+     * @param fixedTasks
+     *            all fixed tasks in this build
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param header
+     *            header to be shown on detail page
+     * @deprecated use {@link #FixedTasksDetail(Run, Collection, String, String)} instead
+     */
+    @Deprecated
+    public FixedTasksDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> fixedTasks, final String defaultEncoding, final String header) {
+        this((Run<?, ?>) owner, fixedTasks, defaultEncoding, header);
     }
 }
 

--- a/src/main/java/hudson/plugins/tasks/FixedTasksDetail.java
+++ b/src/main/java/hudson/plugins/tasks/FixedTasksDetail.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tasks;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -37,24 +36,6 @@ public class FixedTasksDetail extends FixedWarningsDetail {
     @Override
     public String getDisplayName() {
         return Messages.FixedTasksDetail_Name();
-    }
-
-    /**
-     * Creates a new instance of {@link FixedTasksDetail}.
-     *
-     * @param owner
-     *            the current results object as owner of this action
-     * @param fixedTasks
-     *            all fixed tasks in this build
-     * @param defaultEncoding
-     *            the default encoding to be used when reading and parsing files
-     * @param header
-     *            header to be shown on detail page
-     * @deprecated use {@link #FixedTasksDetail(Run, Collection, String, String)} instead
-     */
-    @Deprecated
-    public FixedTasksDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> fixedTasks, final String defaultEncoding, final String header) {
-        this((Run<?, ?>) owner, fixedTasks, defaultEncoding, header);
     }
 }
 

--- a/src/main/java/hudson/plugins/tasks/TasksDetailBuilder.java
+++ b/src/main/java/hudson/plugins/tasks/TasksDetailBuilder.java
@@ -2,7 +2,8 @@ package hudson.plugins.tasks;
 
 import java.util.Collection;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
+
 import hudson.plugins.analysis.util.model.AnnotationContainer;
 import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.views.DetailFactory;
@@ -21,13 +22,13 @@ public class TasksDetailBuilder extends DetailFactory {
     }
 
     @Override
-    protected TabDetail createTabDetail(final AbstractBuild<?, ?> owner,
+    protected TabDetail createTabDetail(final Run<?, ?> owner,
             final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
         return new TasksTabDetail(owner, annotations, url, defaultEncoding);
     }
 
     @Override
-    protected FixedWarningsDetail createFixedWarningsDetail(final AbstractBuild<?, ?> owner,
+    protected FixedWarningsDetail createFixedWarningsDetail(final Run<?, ?> owner,
             final Collection<FileAnnotation> fixedAnnotations, final String defaultEncoding, final String displayName) {
         return new FixedTasksDetail(owner, fixedAnnotations, defaultEncoding, displayName);
     }

--- a/src/main/java/hudson/plugins/tasks/TasksPublisher.java
+++ b/src/main/java/hudson/plugins/tasks/TasksPublisher.java
@@ -11,7 +11,6 @@ import hudson.Launcher;
 import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
 
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.Action;
@@ -212,111 +211,4 @@ public class TasksPublisher extends HealthAwarePublisher {
         return new TasksAnnotationsAggregator(build, launcher, listener, this, getDefaultEncoding(),
                 usePreviousBuildAsReference(), useOnlyStableBuildsAsReference());
     }
-
-    /**
-     * Creates a new instance of <code>TasksPublisher</code>.
-     *
-     * @param healthy
-     *            Report health as 100% when the number of open tasks is less
-     *            than this value
-     * @param unHealthy
-     *            Report health as 0% when the number of open tasks is greater
-     *            than this value
-     * @param thresholdLimit
-     *            determines which warning priorities should be considered when
-     *            evaluating the build stability and health
-     * @param defaultEncoding
-     *            the default encoding to be used when reading and parsing files
-     * @param useDeltaValues
-     *            determines whether the absolute annotations delta or the
-     *            actual annotations set difference should be used to evaluate
-     *            the build stability
-     * @param unstableTotalAll
-     *            annotation threshold
-     * @param unstableTotalHigh
-     *            annotation threshold
-     * @param unstableTotalNormal
-     *            annotation threshold
-     * @param unstableTotalLow
-     *            annotation threshold
-     * @param unstableNewAll
-     *            annotation threshold
-     * @param unstableNewHigh
-     *            annotation threshold
-     * @param unstableNewNormal
-     *            annotation threshold
-     * @param unstableNewLow
-     *            annotation threshold
-     * @param failedTotalAll
-     *            annotation threshold
-     * @param failedTotalHigh
-     *            annotation threshold
-     * @param failedTotalNormal
-     *            annotation threshold
-     * @param failedTotalLow
-     *            annotation threshold
-     * @param failedNewAll
-     *            annotation threshold
-     * @param failedNewHigh
-     *            annotation threshold
-     * @param failedNewNormal
-     *            annotation threshold
-     * @param failedNewLow
-     *            annotation threshold
-     * @param canRunOnFailed
-     *            determines whether the plug-in can run for failed builds, too
-     * @param usePreviousBuildAsReference
-     *            determines whether to always use the previous build as the reference build
-     * @param useStableBuildAsReference
-     *            determines whether only stable builds should be used as reference builds or not
-     * @param canComputeNew
-     *            determines whether new warnings should be computed (with
-     *            respect to baseline)
-     * @param shouldDetectModules
-     *            determines whether module names should be derived from Maven POM or Ant build files
-     * @param high
-     *            tag identifiers indicating high priority
-     * @param normal
-     *            tag identifiers indicating normal priority
-     * @param low
-     *            tag identifiers indicating low priority
-     * @param ignoreCase
-     *            if case should be ignored during matching
-     * @param asRegexp
-     *            if the identifiers should be treated as regular expression
-     * @param pattern
-     *            Ant file-set pattern of files to scan for open tasks in
-     * @param excludePattern
-     *            Ant file-set pattern of files to exclude from scan
-     * @deprecated This constructor is called internally only, but if you need to use it (for some strange reason), call
-     *            {@link #TasksPublisher()} and available setters
-     */
-    // CHECKSTYLE:OFF
-    @SuppressWarnings("PMD.ExcessiveParameterList")
-    @Deprecated
-    public TasksPublisher(final String healthy, final String unHealthy, final String thresholdLimit,
-            final String defaultEncoding, final boolean useDeltaValues,
-            final String unstableTotalAll, final String unstableTotalHigh, final String unstableTotalNormal, final String unstableTotalLow,
-            final String unstableNewAll, final String unstableNewHigh, final String unstableNewNormal, final String unstableNewLow,
-            final String failedTotalAll, final String failedTotalHigh, final String failedTotalNormal, final String failedTotalLow,
-            final String failedNewAll, final String failedNewHigh, final String failedNewNormal, final String failedNewLow,
-            final boolean canRunOnFailed, final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
-            final boolean shouldDetectModules, final boolean canComputeNew, final String high, final String normal, final String low,
-            final boolean ignoreCase, final boolean asRegexp, final String pattern, final String excludePattern) {
-        super(healthy, unHealthy, thresholdLimit, defaultEncoding, useDeltaValues,
-                unstableTotalAll, unstableTotalHigh, unstableTotalNormal, unstableTotalLow,
-                unstableNewAll, unstableNewHigh, unstableNewNormal, unstableNewLow,
-                failedTotalAll, failedTotalHigh, failedTotalNormal, failedTotalLow,
-                failedNewAll, failedNewHigh, failedNewNormal, failedNewLow,
-                canRunOnFailed, usePreviousBuildAsReference, useStableBuildAsReference,
-                shouldDetectModules, canComputeNew, true, PLUGIN_NAME);
-        this.pattern = pattern;
-        this.excludePattern = excludePattern;
-        this.high = high;
-        this.normal = normal;
-        this.low = low;
-        this.ignoreCase = ignoreCase;
-        this.asRegexp = asRegexp;
-    }
-    // CHECKSTYLE:ON
 }

--- a/src/main/java/hudson/plugins/tasks/TasksPublisher.java
+++ b/src/main/java/hudson/plugins/tasks/TasksPublisher.java
@@ -4,14 +4,19 @@ import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
+
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Run;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+
 import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.analysis.core.HealthAwarePublisher;
 import hudson.plugins.analysis.util.PluginLogger;
@@ -30,19 +35,183 @@ public class TasksPublisher extends HealthAwarePublisher {
     /** Default files pattern. */
     private static final String DEFAULT_PATTERN = "**/*.java";
     /** Tag identifiers indicating high priority. */
-    private final String high;
+    private String high;
     /** Tag identifiers indicating normal priority. */
-    private final String normal;
+    private String normal;
     /** Tag identifiers indicating low priority. */
-    private final String low;
+    private String low;
     /** Tag identifiers indicating case sensitivity. */
-    private final boolean ignoreCase;
+    private boolean ignoreCase;
     /** If the identifiers should be treated as regular expression. */
-    private final boolean asRegexp;
+    private boolean asRegexp;
     /** Ant file-set pattern of files to work with. */
-    private final String pattern;
+    private String pattern;
     /** Ant file-set pattern of files to exclude from work. */
-    private final String excludePattern;
+    private String excludePattern;
+    /** Plugin name */
+    private static final String PLUGIN_NAME = "TASKS";
+
+    /**
+     * Simplified default constructor. 
+     * Use setters to initialize if required.
+     */
+    @DataBoundConstructor
+    public TasksPublisher() {
+        super(PLUGIN_NAME);
+    }
+
+    /**
+     * Returns the Ant file-set pattern of files to work with.
+     *
+     * @return Ant file-set pattern of files to work with
+     */
+    public String getPattern() {
+        return pattern;
+    }
+
+    /**
+     * @see {@link #getPattern()}
+     */
+    @DataBoundSetter
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+     /**
+     * Returns the Ant file-set pattern of files to exclude from work.
+     *
+     * @return Ant file-set pattern of files to exclude from work
+     */
+    public String getExcludePattern() {
+        return excludePattern;
+    }
+
+    /**
+     * @see {@link #getExcludePattern()}
+     */
+    @DataBoundSetter
+    public void setExcludePattern(String excludePattern) {
+        this.excludePattern = excludePattern;
+    }
+
+    /**
+     * Returns the high priority task identifiers.
+     *
+     * @return the high priority task identifiers
+     */
+    public String getHigh() {
+        return high;
+    }
+
+    /**
+     * @see {@link #getHigh()}
+     */
+    @DataBoundSetter
+    public void setHigh(String high) {
+        this.high = high;
+    }
+
+    /**
+     * Returns the normal priority task identifiers.
+     *
+     * @return the normal priority task identifiers
+     */
+    public String getNormal() {
+        return normal;
+    }
+
+    /**
+     * @see {@link #getNormal()}
+     */
+    @DataBoundSetter
+    public void setNormal(String normal) {
+        this.normal = normal;
+    }
+
+    /**
+     * Returns the low priority task identifiers.
+     *
+     * @return the low priority task identifiers
+     */
+    public String getLow() {
+        return low;
+    }
+
+    /**
+     * @see {@link #getLow()}
+     */
+    @DataBoundSetter
+    public void setLow(String low) {
+        this.low = low;
+    }
+
+    /**
+     * Returns whether case should be ignored during the scanning.
+     *
+     * @return <code>true</code> if case should be ignored during the scanning
+     */
+    public boolean getIgnoreCase() {
+        return ignoreCase;
+    }
+
+    /**
+     * @see {@link #getIgnoreCase()}
+     */
+    @DataBoundSetter
+    public void setIgnoreCase(boolean ignoreCase) {
+        this.ignoreCase = ignoreCase;
+    }
+
+    /**
+     * Returns whether the identifiers should be treated as regular expression.
+     *
+     * @return <code>true</code> if the identifiers should be treated as regular expression
+     */
+    public boolean getAsRegexp() {
+        return asRegexp;
+    }
+
+    /**
+     * @see {@link #getAsRegexp()}
+     */
+    @DataBoundSetter
+    public void setAsRegexp(boolean asRegexp) {
+        this.asRegexp = asRegexp;
+    }
+
+    @Override
+    public Action getProjectAction(final AbstractProject<?, ?> project) {
+        return new TasksProjectAction(project);
+    }
+
+    @Override
+    protected BuildResult perform(final Run<?, ?> build, FilePath workspace, final PluginLogger logger) throws InterruptedException, IOException {
+        TasksParserResult project;
+        WorkspaceScanner scanner = new WorkspaceScanner(StringUtils.defaultIfEmpty(getPattern(), DEFAULT_PATTERN),
+                getExcludePattern(), getDefaultEncoding(), high, normal, low, ignoreCase, shouldDetectModules(), asRegexp);
+        project = workspace.act(scanner);
+
+        logger.logLines(project.getLogMessages());
+        logger.log(String.format("Found %d open tasks.", project.getNumberOfAnnotations()));
+
+        TasksResult result = new TasksResult(build, getDefaultEncoding(), project,
+                usePreviousBuildAsReference(), useOnlyStableBuildsAsReference(), high, normal, low);
+        build.addAction(new TasksResultAction(build, this, result));
+
+        return result;
+    }
+
+    @Override
+    public TasksDescriptor getDescriptor() {
+        return (TasksDescriptor)super.getDescriptor();
+    }
+
+    @Override
+    public MatrixAggregator createAggregator(final MatrixBuild build, final Launcher launcher,
+            final BuildListener listener) {
+        return new TasksAnnotationsAggregator(build, launcher, listener, this, getDefaultEncoding(),
+                usePreviousBuildAsReference(), useOnlyStableBuildsAsReference());
+    }
 
     /**
      * Creates a new instance of <code>TasksPublisher</code>.
@@ -119,10 +288,12 @@ public class TasksPublisher extends HealthAwarePublisher {
      *            Ant file-set pattern of files to scan for open tasks in
      * @param excludePattern
      *            Ant file-set pattern of files to exclude from scan
+     * @deprecated This constructor is called internally only, but if you need to use it (for some strange reason), call
+     *            {@link #TasksPublisher()} and available setters
      */
     // CHECKSTYLE:OFF
     @SuppressWarnings("PMD.ExcessiveParameterList")
-    @DataBoundConstructor
+    @Deprecated
     public TasksPublisher(final String healthy, final String unHealthy, final String thresholdLimit,
             final String defaultEncoding, final boolean useDeltaValues,
             final String unstableTotalAll, final String unstableTotalHigh, final String unstableTotalNormal, final String unstableTotalLow,
@@ -138,7 +309,7 @@ public class TasksPublisher extends HealthAwarePublisher {
                 failedTotalAll, failedTotalHigh, failedTotalNormal, failedTotalLow,
                 failedNewAll, failedNewHigh, failedNewNormal, failedNewLow,
                 canRunOnFailed, usePreviousBuildAsReference, useStableBuildAsReference,
-                shouldDetectModules, canComputeNew, true, "TASKS");
+                shouldDetectModules, canComputeNew, true, PLUGIN_NAME);
         this.pattern = pattern;
         this.excludePattern = excludePattern;
         this.high = high;
@@ -148,101 +319,4 @@ public class TasksPublisher extends HealthAwarePublisher {
         this.asRegexp = asRegexp;
     }
     // CHECKSTYLE:ON
-
-    /**
-     * Returns the Ant file-set pattern of files to work with.
-     *
-     * @return Ant file-set pattern of files to work with
-     */
-    public String getPattern() {
-        return pattern;
-    }
-
-     /**
-     * Returns the Ant file-set pattern of files to exclude from work.
-     *
-     * @return Ant file-set pattern of files to exclude from work
-     */
-    public String getExcludePattern() {
-        return excludePattern;
-    }
-
-    /**
-     * Returns the high priority task identifiers.
-     *
-     * @return the high priority task identifiers
-     */
-    public String getHigh() {
-        return high;
-    }
-
-    /**
-     * Returns the normal priority task identifiers.
-     *
-     * @return the normal priority task identifiers
-     */
-    public String getNormal() {
-        return normal;
-    }
-
-    /**
-     * Returns the low priority task identifiers.
-     *
-     * @return the low priority task identifiers
-     */
-    public String getLow() {
-        return low;
-    }
-
-    /**
-     * Returns whether case should be ignored during the scanning.
-     *
-     * @return <code>true</code> if case should be ignored during the scanning
-     */
-    public boolean getIgnoreCase() {
-        return ignoreCase;
-    }
-
-    /**
-     * Returns whether the identifiers should be treated as regular expression.
-     *
-     * @return <code>true</code> if the identifiers should be treated as regular expression
-     */
-    public boolean getAsRegexp() {
-        return asRegexp;
-    }
-
-    @Override
-    public Action getProjectAction(final AbstractProject<?, ?> project) {
-        return new TasksProjectAction(project);
-    }
-
-    @Override
-    protected BuildResult perform(final AbstractBuild<?, ?> build, final PluginLogger logger) throws InterruptedException, IOException {
-        TasksParserResult project;
-        WorkspaceScanner scanner = new WorkspaceScanner(StringUtils.defaultIfEmpty(getPattern(), DEFAULT_PATTERN),
-                getExcludePattern(), getDefaultEncoding(), high, normal, low, ignoreCase, shouldDetectModules(), asRegexp);
-        project = build.getWorkspace().act(scanner);
-
-        logger.logLines(project.getLogMessages());
-        logger.log(String.format("Found %d open tasks.", project.getNumberOfAnnotations()));
-
-        TasksResult result = new TasksResult(build, getDefaultEncoding(), project,
-                usePreviousBuildAsReference(), useOnlyStableBuildsAsReference(), high, normal, low);
-        build.addAction(new TasksResultAction(build, this, result));
-
-        return result;
-    }
-
-    @Override
-    public TasksDescriptor getDescriptor() {
-        return (TasksDescriptor)super.getDescriptor();
-    }
-
-    @Override
-    public MatrixAggregator createAggregator(final MatrixBuild build, final Launcher launcher,
-            final BuildListener listener) {
-        return new TasksAnnotationsAggregator(build, launcher, listener, this, getDefaultEncoding(),
-                usePreviousBuildAsReference(), useOnlyStableBuildsAsReference());
-    }
 }

--- a/src/main/java/hudson/plugins/tasks/TasksReporterResult.java
+++ b/src/main/java/hudson/plugins/tasks/TasksReporterResult.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tasks;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.core.ResultAction;
@@ -46,36 +45,6 @@ public class TasksReporterResult extends TasksResult {
     @Override
     protected Class<? extends ResultAction<? extends BuildResult>> getResultActionType() {
         return TasksMavenResultAction.class;
-    }
-
-    /**
-     * Creates a new instance of {@link TasksReporterResult}.
-     *
-     * @param build
-     *            the current build as owner of this action
-     * @param defaultEncoding
-     *            the default encoding to be used when reading and parsing files
-     * @param result
-     *            the parsed annotations
-     * @param usePreviousBuildAsReference
-     *            determines whether to always use the previous build as the reference build
-     * @param useStableBuildAsReference
-     *            determines whether only stable builds should be used as
-     *            reference builds or not
-     * @param highTags
-     *            tag identifiers indicating high priority
-     * @param normalTags
-     *            tag identifiers indicating normal priority
-     * @param lowTags
-     *            tag identifiers indicating low priority
-     * @deprecated use {@link #TasksReporterResult(Run, String, TasksParserResult, boolean, boolean, String, String, String)} instead
-     */
-    @Deprecated
-    public TasksReporterResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
-            final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
-            final String highTags, final String normalTags, final String lowTags) {
-        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
-                highTags, normalTags, lowTags);
     }
 }
 

--- a/src/main/java/hudson/plugins/tasks/TasksReporterResult.java
+++ b/src/main/java/hudson/plugins/tasks/TasksReporterResult.java
@@ -1,6 +1,8 @@
 package hudson.plugins.tasks;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+
 import hudson.plugins.analysis.core.ResultAction;
 import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.tasks.parser.TasksParserResult;
@@ -34,7 +36,7 @@ public class TasksReporterResult extends TasksResult {
      * @param lowTags
      *            tag identifiers indicating low priority
      */
-    public TasksReporterResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
+    public TasksReporterResult(final Run<?, ?> build, final String defaultEncoding, final TasksParserResult result,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
             final String highTags, final String normalTags, final String lowTags) {
         super(build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
@@ -44,6 +46,36 @@ public class TasksReporterResult extends TasksResult {
     @Override
     protected Class<? extends ResultAction<? extends BuildResult>> getResultActionType() {
         return TasksMavenResultAction.class;
+    }
+
+    /**
+     * Creates a new instance of {@link TasksReporterResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param result
+     *            the parsed annotations
+     * @param usePreviousBuildAsReference
+     *            determines whether to always use the previous build as the reference build
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     * @param highTags
+     *            tag identifiers indicating high priority
+     * @param normalTags
+     *            tag identifiers indicating normal priority
+     * @param lowTags
+     *            tag identifiers indicating low priority
+     * @deprecated use {@link #TasksReporterResult(Run, String, TasksParserResult, boolean, boolean, String, String, String)} instead
+     */
+    @Deprecated
+    public TasksReporterResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
+            final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
+            final String highTags, final String normalTags, final String lowTags) {
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
+                highTags, normalTags, lowTags);
     }
 }
 

--- a/src/main/java/hudson/plugins/tasks/TasksResult.java
+++ b/src/main/java/hudson/plugins/tasks/TasksResult.java
@@ -6,7 +6,6 @@ import org.apache.commons.lang.StringUtils;
 
 import com.thoughtworks.xstream.XStream;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.core.BuildHistory;
@@ -219,46 +218,4 @@ public class TasksResult extends BuildResult {
     @Deprecated
     private transient int normalPriorityTasks;
 
-    /**
-     * @deprecated use {@link #TasksResult(Run, String, TasksParserResult, boolean, boolean, String, String, String)} instead
-     */
-    @Deprecated
-    protected TasksResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
-            final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
-            final String highTags, final String normalTags, final String lowTags,
-            final Class<? extends ResultAction<TasksResult>> actionType) {
-        // CHECKSTYLE:ON
-        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference, 
-                highTags, normalTags, lowTags, actionType);
-    }
-    
-    /**
-     * Creates a new instance of {@link TasksResult}.
-     *
-     * @param build
-     *            the current build as owner of this action
-     * @param defaultEncoding
-     *            the default encoding to be used when reading and parsing files
-     * @param result
-     *            the parsed annotations
-     * @param usePreviousBuildAsReference
-     *            determines whether to always use the previous build as the reference build
-     * @param useStableBuildAsReference
-     *            determines whether only stable builds should be used as
-     *            reference builds or not
-     * @param highTags
-     *            tag identifiers indicating high priority
-     * @param normalTags
-     *            tag identifiers indicating normal priority
-     * @param lowTags
-     *            tag identifiers indicating low priority
-     * @deprecated use {@link #TasksResult(Run, String, TasksParserResult, boolean, boolean, String, String, String)} instead
-     */
-    @Deprecated
-    public TasksResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
-            final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
-            final String highTags, final String normalTags, final String lowTags) {
-        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
-                highTags, normalTags, lowTags);
-    }
 }

--- a/src/main/java/hudson/plugins/tasks/TasksResult.java
+++ b/src/main/java/hudson/plugins/tasks/TasksResult.java
@@ -7,9 +7,11 @@ import org.apache.commons.lang.StringUtils;
 import com.thoughtworks.xstream.XStream;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+
 import hudson.plugins.analysis.core.BuildHistory;
-import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.analysis.core.ResultAction;
+import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.analysis.util.model.AnnotationContainer;
 import hudson.plugins.analysis.util.model.Priority;
 import hudson.plugins.tasks.parser.Task;
@@ -51,7 +53,7 @@ public class TasksResult extends BuildResult {
      * @param lowTags
      *            tag identifiers indicating low priority
      */
-    public TasksResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
+    public TasksResult(final Run<?, ?> build, final String defaultEncoding, final TasksParserResult result,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
             final String highTags, final String normalTags, final String lowTags) {
         this(build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
@@ -82,7 +84,7 @@ public class TasksResult extends BuildResult {
      *            the type of the result action
      */
     // CHECKSTYLE:OFF
-    protected TasksResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
+    protected TasksResult(final Run<?, ?> build, final String defaultEncoding, final TasksParserResult result,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
             final String highTags, final String normalTags, final String lowTags,
             final Class<? extends ResultAction<TasksResult>> actionType) {
@@ -216,4 +218,47 @@ public class TasksResult extends BuildResult {
     @SuppressWarnings("PMD")
     @Deprecated
     private transient int normalPriorityTasks;
+
+    /**
+     * @deprecated use {@link #TasksResult(Run, String, TasksParserResult, boolean, boolean, String, String, String)} instead
+     */
+    @Deprecated
+    protected TasksResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
+            final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
+            final String highTags, final String normalTags, final String lowTags,
+            final Class<? extends ResultAction<TasksResult>> actionType) {
+        // CHECKSTYLE:ON
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference, 
+                highTags, normalTags, lowTags, actionType);
+    }
+    
+    /**
+     * Creates a new instance of {@link TasksResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param result
+     *            the parsed annotations
+     * @param usePreviousBuildAsReference
+     *            determines whether to always use the previous build as the reference build
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     * @param highTags
+     *            tag identifiers indicating high priority
+     * @param normalTags
+     *            tag identifiers indicating normal priority
+     * @param lowTags
+     *            tag identifiers indicating low priority
+     * @deprecated use {@link #TasksResult(Run, String, TasksParserResult, boolean, boolean, String, String, String)} instead
+     */
+    @Deprecated
+    public TasksResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final TasksParserResult result,
+            final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference,
+            final String highTags, final String normalTags, final String lowTags) {
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
+                highTags, normalTags, lowTags);
+    }
 }

--- a/src/main/java/hudson/plugins/tasks/TasksResultAction.java
+++ b/src/main/java/hudson/plugins/tasks/TasksResultAction.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tasks;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.core.HealthDescriptor;
@@ -54,19 +53,4 @@ public class TasksResultAction extends AbstractResultAction<TasksResult>  {
         return Messages.Tasks_ResultAction_OneWarning();
     }
 
-    /**
-     * Creates a new instance of <code>TasksResultAction</code>.
-     *
-     * @param owner
-     *            the associated build of this action
-     * @param healthDescriptor
-     *            health descriptor to use
-     * @param result
-     *            the result in this build
-     * @deprecated use {@link #TasksResultAction(Run, HealthDescriptor, TasksResult)} instead
-     */
-    @Deprecated
-    public TasksResultAction(final AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor, final TasksResult result) {
-        this((Run<?, ?>) owner, healthDescriptor, result);
-    }
 }

--- a/src/main/java/hudson/plugins/tasks/TasksResultAction.java
+++ b/src/main/java/hudson/plugins/tasks/TasksResultAction.java
@@ -1,6 +1,8 @@
 package hudson.plugins.tasks;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+
 import hudson.plugins.analysis.core.HealthDescriptor;
 import hudson.plugins.analysis.core.PluginDescriptor;
 import hudson.plugins.analysis.core.AbstractResultAction;
@@ -17,17 +19,18 @@ import hudson.plugins.analysis.core.AbstractResultAction;
  * @author Ulli Hafner
  */
 public class TasksResultAction extends AbstractResultAction<TasksResult>  {
+
     /**
      * Creates a new instance of <code>TasksResultAction</code>.
      *
      * @param owner
-     *            the associated build of this action
+     *            the associated owner of this action
      * @param healthDescriptor
      *            health descriptor to use
      * @param result
      *            the result in this build
      */
-    public TasksResultAction(final AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor, final TasksResult result) {
+    public TasksResultAction(final Run<?, ?> owner, final HealthDescriptor healthDescriptor, final TasksResult result) {
         super(owner, new TasksHealthDescriptor(healthDescriptor), result);
     }
 
@@ -49,5 +52,21 @@ public class TasksResultAction extends AbstractResultAction<TasksResult>  {
     @Override
     public String getSingleItemTooltip() {
         return Messages.Tasks_ResultAction_OneWarning();
+    }
+
+    /**
+     * Creates a new instance of <code>TasksResultAction</code>.
+     *
+     * @param owner
+     *            the associated build of this action
+     * @param healthDescriptor
+     *            health descriptor to use
+     * @param result
+     *            the result in this build
+     * @deprecated use {@link #TasksResultAction(Run, HealthDescriptor, TasksResult)} instead
+     */
+    @Deprecated
+    public TasksResultAction(final AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor, final TasksResult result) {
+        this((Run<?, ?>) owner, healthDescriptor, result);
     }
 }

--- a/src/main/java/hudson/plugins/tasks/TasksTabDetail.java
+++ b/src/main/java/hudson/plugins/tasks/TasksTabDetail.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tasks;
 
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 
 import hudson.plugins.analysis.util.model.FileAnnotation;
@@ -47,24 +46,6 @@ public class TasksTabDetail extends TabDetail {
     @Override
     public String getFixed() {
         return "tasks-fixed.jelly";
-    }
-
-    /**
-     * Creates a new instance of <code>ModuleDetail</code>.
-     *
-     * @param owner
-     *            current build as owner of this action.
-     * @param annotations
-     *            the container to show the details for
-     * @param url
-     *            URL to render the content of this tab
-     * @param defaultEncoding
-     *            the default encoding to be used when reading and parsing files
-     * @deprecated use {@link #TasksTabDetail(Run, Collection, String, String)} instead
-     */
-    @Deprecated
-    public TasksTabDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
-        this((Run<?, ?>) owner, annotations, url, defaultEncoding);
     }
 }
 

--- a/src/main/java/hudson/plugins/tasks/TasksTabDetail.java
+++ b/src/main/java/hudson/plugins/tasks/TasksTabDetail.java
@@ -1,6 +1,8 @@
 package hudson.plugins.tasks;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
+
 import hudson.plugins.analysis.util.model.FileAnnotation;
 import hudson.plugins.analysis.views.DetailFactory;
 import hudson.plugins.analysis.views.TabDetail;
@@ -28,7 +30,7 @@ public class TasksTabDetail extends TabDetail {
      * @param defaultEncoding
      *            the default encoding to be used when reading and parsing files
      */
-    public TasksTabDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
+    public TasksTabDetail(final Run<?, ?> owner, final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
         super(owner, new DetailFactory(), annotations, url, defaultEncoding);
     }
 
@@ -45,6 +47,24 @@ public class TasksTabDetail extends TabDetail {
     @Override
     public String getFixed() {
         return "tasks-fixed.jelly";
+    }
+
+    /**
+     * Creates a new instance of <code>ModuleDetail</code>.
+     *
+     * @param owner
+     *            current build as owner of this action.
+     * @param annotations
+     *            the container to show the details for
+     * @param url
+     *            URL to render the content of this tab
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @deprecated use {@link #TasksTabDetail(Run, Collection, String, String)} instead
+     */
+    @Deprecated
+    public TasksTabDetail(final AbstractBuild<?, ?> owner, final Collection<FileAnnotation> annotations, final String url, final String defaultEncoding) {
+        this((Run<?, ?>) owner, annotations, url, defaultEncoding);
     }
 }
 

--- a/src/main/java/hudson/plugins/tasks/parser/WorkspaceScanner.java
+++ b/src/main/java/hudson/plugins/tasks/parser/WorkspaceScanner.java
@@ -6,11 +6,12 @@ import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.List;
 
+import jenkins.MasterToSlaveFileCallable;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.types.FileSet;
 
 import hudson.FilePath;
-import hudson.FilePath.FileCallable;
 
 import hudson.plugins.analysis.util.ContextHashCode;
 import hudson.plugins.analysis.util.EncodingValidator;
@@ -28,7 +29,7 @@ import hudson.remoting.VirtualChannel;
  * @author Ulli Hafner
  */
 // CHECKSTYLE:COUPLING-OFF
-public class WorkspaceScanner implements FileCallable<TasksParserResult> {
+public class WorkspaceScanner extends MasterToSlaveFileCallable<TasksParserResult> {
     /** Generated ID. */
     private static final long serialVersionUID = -4355362392102020724L;
     /** Ant file-set pattern to define the files to scan. */
@@ -244,7 +245,7 @@ public class WorkspaceScanner implements FileCallable<TasksParserResult> {
         return result;
     }
 
-    private InputStreamReader readFile(final File originalFile) throws IOException {
+    private InputStreamReader readFile(final File originalFile) throws IOException, InterruptedException {
         return new InputStreamReader(new FilePath(originalFile).read(),
                     EncodingValidator.defaultCharset(defaultEncoding));
     }

--- a/src/test/java/hudson/plugins/tasks/workflow/WorkflowCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/tasks/workflow/WorkflowCompatibilityTest.java
@@ -1,0 +1,82 @@
+package hudson.plugins.tasks.workflow;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.FilePath;
+
+import hudson.model.Result;
+
+import hudson.plugins.tasks.TasksResultAction;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test workflow compatibility.
+ */
+public class WorkflowCompatibilityTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    private static final String TASKS_FILE = "/hudson/plugins/tasks/parser/file-with-tasks.txt";
+
+    /**
+     * Run a workflow job using {@link TasksPublisher} and check for success.
+     */
+    @Test
+    public void tasksPublisherWorkflowStep() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "wf");
+        FilePath workspace = j.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("tasks.txt");
+        report.copyFrom(WorkflowCompatibilityTest.class.getResourceAsStream(TASKS_FILE));
+        job.setDefinition(new CpsFlowDefinition(
+        "node {" +
+        "  step([$class: 'TasksPublisher', pattern: '**/tasks.txt', high: 'FIXME', normal: 'TODO'])" +
+        "}"));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
+        assertTrue(result.getResult().getAnnotations().size() == 2);
+    }
+
+    /**
+     * Run a workflow job using {@link TasksPublisher} with a failing threshols of 0, so the given example file
+     * "/hudson/plugins/tasks/parser/tasks-case-test.txt" will make the build to fail.
+     */
+    @Test
+    public void tasksPublisherWorkflowStepSetLimits() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "wf2");
+        FilePath workspace = j.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("tasks.txt");
+        report.copyFrom(WorkflowCompatibilityTest.class.getResourceAsStream(TASKS_FILE));
+        job.setDefinition(new CpsFlowDefinition(
+        "node {" +
+        "  step([$class: 'TasksPublisher', pattern: '**/tasks.txt', high: 'FIXME', normal: 'TODO', failedTotalAll: '0', usePreviousBuildAsReference: false])" +
+        "}"));
+        j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
+        TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
+        assertTrue(result.getResult().getAnnotations().size() == 2);
+    }
+
+    /**
+     * Run a workflow job using {@link TasksPublisher} with a unstable threshols of 0, so the given example file
+     * "/hudson/plugins/tasks/parser/tasks-case-test.txt" will make the build to fail.
+     */
+    @Test
+    public void tasksPublisherWorkflowStepFailure() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "wf3");
+        FilePath workspace = j.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("tasks.txt");
+        report.copyFrom(WorkflowCompatibilityTest.class.getResourceAsStream(TASKS_FILE));
+        job.setDefinition(new CpsFlowDefinition(
+        "node {" +
+        "  step([$class: 'TasksPublisher', pattern: '**/tasks.txt', high: 'FIXME', normal: 'TODO', unstableTotalAll: '0', usePreviousBuildAsReference: false])" +
+        "}"));
+        j.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
+        TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
+        assertTrue(result.getResult().getAnnotations().size() == 2);
+    }
+}

--- a/src/test/java/hudson/plugins/tasks/workflow/WorkflowCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/tasks/workflow/WorkflowCompatibilityTest.java
@@ -1,18 +1,19 @@
 package hudson.plugins.tasks.workflow;
 
+import static org.junit.Assert.*;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import hudson.FilePath;
-
 import hudson.model.Result;
 
+import hudson.plugins.tasks.TasksPublisher;
 import hudson.plugins.tasks.TasksResultAction;
 
-import static org.junit.Assert.*;
+import hudson.FilePath;
 
 /**
  * Test workflow compatibility.
@@ -43,7 +44,7 @@ public class WorkflowCompatibilityTest {
         TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
 
         // The result has to report exactly 2 annotations coming from two tasks markers in the original file
-        assertTrue(result.getResult().getAnnotations().size() == 2);
+        assertEquals(result.getResult().getAnnotations().size(), 2);
     }
 
     /**
@@ -61,12 +62,12 @@ public class WorkflowCompatibilityTest {
         "  step([$class: 'TasksPublisher', pattern: '**/tasks.txt', high: 'FIXME', normal: 'TODO', failedTotalAll: '0', usePreviousBuildAsReference: false])" +
         "}"));
 
-        // The build must fail, since there is a failing threshold set (failedTotalAll: '0') 
+        // The build must fail, since there is a failing threshold set (failedTotalAll: '0')
         j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
         TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
 
         // The result has to report exactly 2 annotations coming from two tasks markers in the original file
-        assertTrue(result.getResult().getAnnotations().size() == 2);
+        assertEquals(result.getResult().getAnnotations().size(), 2);
     }
 
     /**
@@ -84,11 +85,11 @@ public class WorkflowCompatibilityTest {
         "  step([$class: 'TasksPublisher', pattern: '**/tasks.txt', high: 'FIXME', normal: 'TODO', unstableTotalAll: '0', usePreviousBuildAsReference: false])" +
         "}"));
 
-        // The build must report unstability, since there is an unstable threshold set (unstableTotalAll: '0') 
+        // The build must report unstability, since there is an unstable threshold set (unstableTotalAll: '0')
         j.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
         TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
 
         // The result has to report exactly 2 annotations coming from two tasks markers in the original file
-        assertTrue(result.getResult().getAnnotations().size() == 2);
+        assertEquals(result.getResult().getAnnotations().size(), 2);
     }
 }

--- a/src/test/java/hudson/plugins/tasks/workflow/WorkflowCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/tasks/workflow/WorkflowCompatibilityTest.java
@@ -37,8 +37,12 @@ public class WorkflowCompatibilityTest {
         "node {" +
         "  step([$class: 'TasksPublisher', pattern: '**/tasks.txt', high: 'FIXME', normal: 'TODO'])" +
         "}"));
+
+        // Build must be success, since there are no thresholds set
         j.assertBuildStatusSuccess(job.scheduleBuild2(0));
         TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
+
+        // The result has to report exactly 2 annotations coming from two tasks markers in the original file
         assertTrue(result.getResult().getAnnotations().size() == 2);
     }
 
@@ -56,8 +60,12 @@ public class WorkflowCompatibilityTest {
         "node {" +
         "  step([$class: 'TasksPublisher', pattern: '**/tasks.txt', high: 'FIXME', normal: 'TODO', failedTotalAll: '0', usePreviousBuildAsReference: false])" +
         "}"));
+
+        // The build must fail, since there is a failing threshold set (failedTotalAll: '0') 
         j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
         TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
+
+        // The result has to report exactly 2 annotations coming from two tasks markers in the original file
         assertTrue(result.getResult().getAnnotations().size() == 2);
     }
 
@@ -75,8 +83,12 @@ public class WorkflowCompatibilityTest {
         "node {" +
         "  step([$class: 'TasksPublisher', pattern: '**/tasks.txt', high: 'FIXME', normal: 'TODO', unstableTotalAll: '0', usePreviousBuildAsReference: false])" +
         "}"));
+
+        // The build must report unstability, since there is an unstable threshold set (unstableTotalAll: '0') 
         j.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
         TasksResultAction result = job.getLastBuild().getAction(TasksResultAction.class);
+
+        // The result has to report exactly 2 annotations coming from two tasks markers in the original file
         assertTrue(result.getResult().getAnnotations().size() == 2);
     }
 }


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/analysis-core-plugin/pull/31

https://issues.jenkins-ci.org/browse/JENKINS-29704

This changes allow to use ```TasksPublisher``` in a Workflow script, for example:

```
node {
  step([$class: 'TasksPublisher', high: 'FIXME', normal: 'TODO', failedTotalAll: '0'])
}
```